### PR TITLE
Deprecate this crate for 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "trim_lines"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["neil"]
 description = "An extremely simple and tiny library which provides an iterator over the lines of a string, trimmed of whitespace. It is a simple wrapper around the Lines iterator in std::str which trims the whitespace from each line."
 license = "ISC"
 repository = "https://github.com/nlburgin/trim_lines"
+edition = "2018"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # trim_lines
+
+**NOTE**: This crate is **depreciated**. You should be using `map(str::trim)` instead:
+
+```rust
+fn main() {
+    let text = "    foo    \r\n    bar    \n   \n    baz    \n";
+    let mut lines = text.lines().map(str::trim);
+    assert_eq!(Some("foo"), lines.next());
+    assert_eq!(Some("bar"), lines.next());
+    assert_eq!(Some(""), lines.next());
+    assert_eq!(Some("baz"), lines.next());
+    assert_eq!(None, lines.next());
+}
+```
+
 An extremely simple and tiny library which provides an iterator over the lines of a string, trimmed of whitespace. It is a simple wrapper around the Lines iterator in std::str which trims the whitespace from each line.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # trim_lines
 
-**NOTE**: This crate is **depreciated**. You should be using `map(str::trim)` instead:
+**NOTE**: This crate is **deprecated**. You should be using `map(str::trim)` instead:
 
 ```rust
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
+#![deprecated(since="0.2.0", note="please use `map(str::trim)` instead")]
 pub use std::str::Lines;
 
 ///A wrapper around Lines which trims the whitespace from each line.
-pub struct TrimLines<'a>{
-    l:Lines<'a>,
+pub struct TrimLines<'a> {
+    l: Lines<'a>,
 }
 
 impl<'a> Iterator for TrimLines<'a> {
@@ -10,7 +11,7 @@ impl<'a> Iterator for TrimLines<'a> {
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
         let n = self.l.next();
-        match n{
+        match n {
             Some(s) => Some(s.trim()),
             None => None,
         }
@@ -20,28 +21,53 @@ impl<'a> Iterator for TrimLines<'a> {
 impl<'a> DoubleEndedIterator for TrimLines<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a str> {
-        let n = self.l.next();
-        return match n{
+        let n = self.l.next_back();
+        return match n {
             Some(s) => Some(s.trim()),
             None => None,
         };
     }
 }
 
-impl<'a> TrimLines<'a>{
+impl<'a> TrimLines<'a> {
     ///Create a TrimLines from a Lines.
     #[inline]
-    pub fn new(lines:Lines) -> TrimLines{
-        return TrimLines{
-            l:lines,
-        };
+    pub fn new(lines: Lines) -> TrimLines {
+        return TrimLines { l: lines };
     }
-    
+
     ///Create a TrimLines directly from a string slice.
     #[inline]
-    pub fn from_str(st:&str) -> TrimLines{
-        return TrimLines{
-            l:st.lines(),
-        };
+    pub fn from_str(st: &str) -> TrimLines {
+        return TrimLines { l: st.lines() };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forward_iter() {
+        let text = "    foo    \r\n    bar    \n   \n    baz    \n";
+        let mut lines = TrimLines::new(text.lines());
+
+        assert_eq!(Some("foo"), lines.next());
+        assert_eq!(Some("bar"), lines.next());
+        assert_eq!(Some(""), lines.next());
+        assert_eq!(Some("baz"), lines.next());
+        assert_eq!(None, lines.next());
+    }
+
+    #[test]
+    fn backward_iter() {
+        let text = "    foo    \r\n    bar    \n   \n    baz    \n";
+        let mut lines = TrimLines::new(text.lines());
+
+        assert_eq!(Some("baz"), lines.next_back());
+        assert_eq!(Some(""), lines.next_back());
+        assert_eq!(Some("bar"), lines.next_back());
+        assert_eq!(Some("foo"), lines.next_back());
+        assert_eq!(None, lines.next_back());
     }
 }


### PR DESCRIPTION
Closes #1.

This PR:

* Adds a notice in the README that this crate is deprecated
* Formats the crate through `cargo fmt`
* Deprecates the crate and bumps the ver. to `0.2.0`
* Fixes the logic error in the `DoubleEndedIterator` implementation
* writes tests for each of the iterators.
* uses edition 2018